### PR TITLE
Add automated k0sworker node-ip update service

### DIFF
--- a/roles/k8s_worker/files/k0sworker-nodeip-update.service
+++ b/roles/k8s_worker/files/k0sworker-nodeip-update.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Update k0sworker node-ip if IP address has changed
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/update_k0sworker_nodeip.sh
+User=root
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+

--- a/roles/k8s_worker/files/k0sworker-nodeip-update.timer
+++ b/roles/k8s_worker/files/k0sworker-nodeip-update.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Timer for k0sworker node-ip update
+After=network-online.target
+Wants=network-online.target
+
+[Timer]
+Unit=k0sworker-nodeip-update.service
+OnBootSec=1min
+OnUnitActiveSec=5min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target
+

--- a/roles/k8s_worker/files/update_k0sworker_nodeip.sh
+++ b/roles/k8s_worker/files/update_k0sworker_nodeip.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Update k0sworker.service --node-ip parameter if IP address has changed
+#
+
+SERVICE_FILE="/etc/systemd/system/k0sworker.service"
+LOG_FILE="/var/log/k0sworker-nodeip-update.log"
+
+# Function to log messages
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Get current IP address
+CURRENT_IP=$(ip route get 1.1.1.1 2>/dev/null | sed -nE 's/.*src ([0-9.]+).*/\1/p' || echo "")
+
+if [ -z "$CURRENT_IP" ]; then
+    log "ERROR: Failed to get current IP address"
+    exit 1
+fi
+
+log "Current IP address: $CURRENT_IP"
+
+# Get current node-ip from service file
+if [ ! -f "$SERVICE_FILE" ]; then
+    log "ERROR: Service file $SERVICE_FILE not found"
+    exit 1
+fi
+
+CURRENT_NODE_IP=$(grep -- '--node-ip=' "$SERVICE_FILE" | sed -nE 's/.*--node-ip=([0-9.]+).*/\1/p' | head -n1 || echo "")
+
+if [ -z "$CURRENT_NODE_IP" ]; then
+    log "WARNING: Could not find --node-ip in service file. Service file may need manual configuration."
+    exit 1
+fi
+
+log "Current node-ip in service file: $CURRENT_NODE_IP"
+
+# Compare IP addresses
+if [ "$CURRENT_IP" = "$CURRENT_NODE_IP" ]; then
+    log "IP address matches. No update needed."
+    exit 0
+fi
+
+log "IP address mismatch detected. Updating service file..."
+
+# Update service file
+sed -i.bak -E "s/--node-ip=[0-9.]+/--node-ip=$CURRENT_IP/" "$SERVICE_FILE"
+
+if [ $? -ne 0 ]; then
+    log "ERROR: Failed to update service file"
+    exit 1
+fi
+
+log "Service file updated successfully."
+
+# Reload systemd daemon
+systemctl daemon-reload
+
+if [ $? -ne 0 ]; then
+    log "ERROR: Failed to reload systemd daemon"
+    exit 1
+fi
+
+log "Systemd daemon reloaded."
+
+# Restart k0sworker service
+systemctl restart k0sworker
+
+if [ $? -ne 0 ]; then
+    log "ERROR: Failed to restart k0sworker service"
+    exit 1
+fi
+
+log "k0sworker service restarted successfully. IP address updated from $CURRENT_NODE_IP to $CURRENT_IP"
+exit 0
+

--- a/roles/k8s_worker/tasks/main.yaml
+++ b/roles/k8s_worker/tasks/main.yaml
@@ -2,4 +2,5 @@
 - import_tasks: topology.yaml
 - import_tasks: lustre.yaml
 - import_tasks: reset_cpu_memory_manager.yaml
+- import_tasks: update_nodeip.yaml
 #- import_tasks: cert.yaml

--- a/roles/k8s_worker/tasks/update_nodeip.yaml
+++ b/roles/k8s_worker/tasks/update_nodeip.yaml
@@ -1,0 +1,37 @@
+---
+#
+# Install k0sworker node-ip auto update service and timer
+#
+- name: Copy update node-ip script
+  ansible.builtin.copy:
+    src: files/update_k0sworker_nodeip.sh
+    dest: /usr/local/bin/update_k0sworker_nodeip.sh
+    mode: '0755'
+  become: yes
+
+- name: Install systemd service for node-ip update
+  ansible.builtin.copy:
+    src: files/k0sworker-nodeip-update.service
+    dest: /etc/systemd/system/k0sworker-nodeip-update.service
+    mode: '0644'
+  become: yes
+
+- name: Install systemd timer for node-ip update
+  ansible.builtin.copy:
+    src: files/k0sworker-nodeip-update.timer
+    dest: /etc/systemd/system/k0sworker-nodeip-update.timer
+    mode: '0644'
+  become: yes
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  become: yes
+
+- name: Enable and start node-ip update timer
+  ansible.builtin.systemd:
+    name: k0sworker-nodeip-update.timer
+    enabled: yes
+    state: started
+  become: yes
+


### PR DESCRIPTION
## Summary

This PR implements an automated solution to update the k0sworker node IP address when the node's IP changes. This addresses issues where k0sworker nodes may get a new IP address (e.g., after reboot or network reconfiguration) but the service configuration doesn't reflect the change.

## Changes

- Added a bash script (`update_k0sworker_nodeip.sh`) that:
  - Detects the current system IP address
  - Compares it with the configured node-ip in the k0sworker service file
  - Updates the service configuration if a mismatch is detected
  - Restarts the k0sworker service after updating
  - Logs all operations to `/var/log/k0sworker-nodeip-update.log`

- Created a systemd service (`k0sworker-nodeip-update.service`) to run the update script
- Created a systemd timer (`k0sworker-nodeip-update.timer`) that:
  - Triggers the service 1 minute after boot
  - Runs every 5 minutes to check for IP changes
  - Ensures network is available before execution

- Added Ansible tasks to deploy and enable the service and timer

## Impact
This change improves cluster reliability by ensuring k0sworker nodes maintain proper connectivity even after IP address changes, reducing manual intervention and potential service disruptions.